### PR TITLE
Make `TextLayout` not own `Source` or `TextStyle`

### DIFF
--- a/src/element/text_context.rs
+++ b/src/element/text_context.rs
@@ -4,8 +4,8 @@ use vello::peniko;
 
 /// State used to measure and render text.
 pub struct TextContext {
-    pub(super) layout_cx: LayoutContext<peniko::Brush>,
     pub(super) font_cx: FontContext,
+    pub(super) layout_cx: LayoutContext<peniko::Brush>,
 }
 
 /// Descriptor for creating a [`TextContext`].
@@ -20,7 +20,6 @@ impl TextContext {
     pub fn new(desc: TextContextDescriptor) -> Self {
         let TextContextDescriptor { use_system_fonts } = desc;
 
-        let layout_cx = LayoutContext::new();
         let font_cx = FontContext {
             collection: Collection::new(CollectionOptions {
                 shared: false,
@@ -28,8 +27,14 @@ impl TextContext {
             }),
             ..Default::default()
         };
+        let layout_cx = LayoutContext::new();
 
-        Self { layout_cx, font_cx }
+        Self { font_cx, layout_cx }
+    }
+
+    /// Returns an iterator over the names of loaded font families.
+    pub fn family_names(&mut self) -> impl Iterator<Item = &str> + Clone {
+        self.font_cx.collection.family_names()
     }
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -92,11 +92,11 @@ impl Renderer {
                     },
                     Command::DrawText { source, bounds, style } => {
                         // TODO: cache layouts
-                        let mut layout =
-                            TextLayout::new(&mut self.text_context, source.clone(), style.clone());
+                        let mut layout = TextLayout::new();
 
                         // TODO: respect vertical bounds
-                        layout.break_lines(bounds.size.w);
+                        layout.build(&mut self.text_context, source, style.clone());
+                        layout.break_lines(bounds.size.w, style.alignment);
                         layout.render(bounds.origin, output);
                     },
                     Command::DrawTextLayout { layout, origin } => {


### PR DESCRIPTION
Fixes #1

This is probably the best we can do for reducing copies without majorly redesigning the entire library.