### PR TITLE
Fix `TextLayout::size` returning zero size without calling `TextLayout::break_lines`

### DIFF
--- a/src/element/text_layout.rs
+++ b/src/element/text_layout.rs
@@ -98,6 +98,7 @@ impl TextLayout {
         }
 
         builder.build_into(&mut self.inner);
+        self.break_lines(f32::MAX, style.alignment);
     }
 
     pub(crate) fn render(&self, origin: Point2<f32>, output: &mut vello::Scene) {


### PR DESCRIPTION
This feels like better behavior.